### PR TITLE
feat: implement getting/setting Ethernet features

### DIFF
--- a/client.go
+++ b/client.go
@@ -376,5 +376,56 @@ func (c *Client) SetRings(r Rings) error {
 	return c.c.SetRings(r)
 }
 
+// StringSet is a set of strings with index-based access.
+type StringSet map[uint32]string
+
+// FeaturesStringSet returns a string set describing the feature bits.
+func (c *Client) FeaturesStringSet() (StringSet, error) {
+	return c.c.FeaturesStringSet()
+}
+
+// FeatureInfo describes the current of features for an interface.
+type FeatureInfo struct {
+	Name      string
+	Supported bool
+	Wanted    bool
+	Active    bool
+	NoChange  bool
+}
+
+func (f FeatureInfo) State() string {
+	switch f.Active {
+	case true:
+		return "on"
+	default:
+		return "off"
+	}
+}
+
+func (f FeatureInfo) Suffix() string {
+	switch {
+	case !f.Supported || f.NoChange:
+		return " [fixed]"
+	case f.Active != f.Wanted:
+		if f.Wanted {
+			return " [requested on]"
+		} else {
+			return " [requested off]"
+		}
+	default:
+		return ""
+	}
+}
+
+// Features returns the feature information for the specified Interface.
+func (c *Client) Features(ifi Interface) ([]FeatureInfo, error) {
+	return c.c.Features(ifi)
+}
+
+// SetFeatures sets the features for the specified Interface.
+func (c *Client) SetFeatures(ifi Interface, features map[string]bool) error {
+	return c.c.SetFeatures(ifi, features)
+}
+
 // Close cleans up the Client's resources.
 func (c *Client) Close() error { return c.c.Close() }

--- a/client_others.go
+++ b/client_others.go
@@ -16,24 +16,27 @@ func (*Error) Is(_ error) bool { return false }
 
 type client struct{}
 
-func newClient() (*client, error)                                 { return nil, errUnsupported }
-func (c *client) LinkInfos() ([]*LinkInfo, error)                 { return nil, errUnsupported }
-func (c *client) LinkInfo(_ Interface) (*LinkInfo, error)         { return nil, errUnsupported }
-func (c *client) LinkModes() ([]*LinkMode, error)                 { return nil, errUnsupported }
-func (c *client) LinkMode(_ Interface) (*LinkMode, error)         { return nil, errUnsupported }
-func (c *client) LinkStates() ([]*LinkState, error)               { return nil, errUnsupported }
-func (c *client) LinkState(_ Interface) (*LinkState, error)       { return nil, errUnsupported }
-func (c *client) WakeOnLANs() ([]*WakeOnLAN, error)               { return nil, errUnsupported }
-func (c *client) WakeOnLAN(_ Interface) (*WakeOnLAN, error)       { return nil, errUnsupported }
-func (c *client) SetWakeOnLAN(_ WakeOnLAN) error                  { return errUnsupported }
-func (c *client) FEC(_ Interface) (*FEC, error)                   { return nil, errUnsupported }
-func (c *client) SetFEC(_ FEC) error                              { return errUnsupported }
-func (c *client) AllPrivateFlags() ([]*PrivateFlags, error)       { return nil, errUnsupported }
-func (c *client) PrivateFlags(_ Interface) (*PrivateFlags, error) { return nil, errUnsupported }
-func (c *client) SetPrivateFlags(_ PrivateFlags) error            { return errUnsupported }
-func (c *client) Rings(_ Interface) (*Rings, error)               { return nil, errUnsupported }
-func (c *client) SetRings(_ Rings) error                          { return errUnsupported }
-func (c *client) Close() error                                    { return errUnsupported }
+func newClient() (*client, error)                                           { return nil, errUnsupported }
+func (c *client) LinkInfos() ([]*LinkInfo, error)                           { return nil, errUnsupported }
+func (c *client) LinkInfo(_ Interface) (*LinkInfo, error)                   { return nil, errUnsupported }
+func (c *client) LinkModes() ([]*LinkMode, error)                           { return nil, errUnsupported }
+func (c *client) LinkMode(_ Interface) (*LinkMode, error)                   { return nil, errUnsupported }
+func (c *client) LinkStates() ([]*LinkState, error)                         { return nil, errUnsupported }
+func (c *client) LinkState(_ Interface) (*LinkState, error)                 { return nil, errUnsupported }
+func (c *client) WakeOnLANs() ([]*WakeOnLAN, error)                         { return nil, errUnsupported }
+func (c *client) WakeOnLAN(_ Interface) (*WakeOnLAN, error)                 { return nil, errUnsupported }
+func (c *client) SetWakeOnLAN(_ WakeOnLAN) error                            { return errUnsupported }
+func (c *client) FEC(_ Interface) (*FEC, error)                             { return nil, errUnsupported }
+func (c *client) SetFEC(_ FEC) error                                        { return errUnsupported }
+func (c *client) AllPrivateFlags() ([]*PrivateFlags, error)                 { return nil, errUnsupported }
+func (c *client) PrivateFlags(_ Interface) (*PrivateFlags, error)           { return nil, errUnsupported }
+func (c *client) SetPrivateFlags(_ PrivateFlags) error                      { return errUnsupported }
+func (c *client) Rings(_ Interface) (*Rings, error)                         { return nil, errUnsupported }
+func (c *client) SetRings(_ Rings) error                                    { return errUnsupported }
+func (c *client) FeaturesStringSet() (StringSet, error)                     { return nil, errUnsupported }
+func (c *client) Features(_ Interface) ([]FeatureInfo, error)               { return nil, errUnsupported }
+func (c *client) SetFeatures(ifi Interface, features map[string]bool) error { return errUnsupported }
+func (c *client) Close() error                                              { return errUnsupported }
 
 func (f *FEC) Supported() FECModes { return 0 }
 


### PR DESCRIPTION
This implements getting/setting features.

```
tx-scatter-gather: off
tx-checksum-ipv4: on
tx-checksum-ip-generic: off [fixed]
tx-checksum-ipv6: on
highdma: on [fixed]
tx-scatter-gather-fraglist: off [fixed]
tx-vlan-hw-insert: on
rx-vlan-hw-parse: on
rx-vlan-filter: off [fixed]
vlan-challenged: off [fixed]
tx-generic-segmentation: off [requested on]
tx-lockless: off [fixed]
netns-local: off [fixed]
rx-gro: on
rx-lro: off [fixed]
tx-tcp-segmentation: off
tx-gso-robust: off [fixed]
tx-tcp-ecn-segmentation: off [fixed]
tx-tcp-mangleid-segmentation: off
tx-tcp6-segmentation: off
tx-fcoe-segmentation: off [fixed]
tx-gre-segmentation: off [fixed]
tx-gre-csum-segmentation: off [fixed]
tx-ipxip4-segmentation: off [fixed]
tx-ipxip6-segmentation: off [fixed]
tx-udp_tnl-segmentation: off [fixed]
tx-udp_tnl-csum-segmentation: off [fixed]
tx-gso-partial: off [fixed]
tx-tunnel-remcsum-segmentation: off [fixed]
tx-sctp-segmentation: off [fixed]
tx-esp-segmentation: off [fixed]
tx-udp-segmentation: off [fixed]
tx-gso-list: off [fixed]
tx-checksum-fcoe-crc: off [fixed]
tx-checksum-sctp: off [fixed]
fcoe-mtu: off [fixed]
rx-ntuple-filter: off [fixed]
rx-hashing: off [fixed]
rx-checksum: on
tx-nocache-copy: off
loopback: off [fixed]
rx-fcs: off
rx-all: off
tx-vlan-stag-hw-insert: off [fixed]
rx-vlan-stag-hw-parse: off [fixed]
rx-vlan-stag-filter: off [fixed]
l2-fwd-offload: off [fixed]
hw-tc-offload: off [fixed]
esp-hw-offload: off [fixed]
esp-tx-csum-hw-offload: off [fixed]
rx-udp_tunnel-port-offload: off [fixed]
tls-hw-tx-offload: off [fixed]
tls-hw-rx-offload: off [fixed]
rx-gro-hw: off [fixed]
tls-hw-record: off [fixed]
rx-gro-list: off
macsec-hw-offload: off [fixed]
rx-udp-gro-forwarding: off
hsr-tag-ins-offload: off [fixed]
hsr-tag-rm-offload: off [fixed]
hsr-fwd-offload: off [fixed]
hsr-dup-offload: off [fixed]
```